### PR TITLE
simple, unified unpacking

### DIFF
--- a/dicthash/test/test_dicthash.py
+++ b/dicthash/test/test_dicthash.py
@@ -142,6 +142,16 @@ class DictHashTest(unittest.TestCase):
         }
         dicthash.generate_hash_from_dict(d0)
 
+    def test_sets_are_flattened(self):
+        d0 = {
+            'a': {1, 2, 3},
+            'b': {(1, 'x'), (5, 'y', 0.1)},
+        }
+        raw0 = dicthash.generate_hash_from_dict(d0, raw=True)
+        self.assertTrue('(' not in raw0)
+        self.assertTrue('[' not in raw0)
+        self.assertTrue('{' not in raw0)
+
     def test_numpy_arrays_are_flattened(self):
         d0 = {
             'a': np.array([1, 2, 3]),


### PR DESCRIPTION
with this PR duck typing (https://en.wikipedia.org/wiki/Duck_typing) is introduced to replace multiple `isinstance` checks: instead of using `if isinstance` (which is error prone) we try to go ahead and unpack the values as if they are dicts or iterables. if an error is raised we catch it and react accordingly. this also addresses issue #7: since we do not need to check what kind of iterable we handle, sets are handled automatically.
