### PR TITLE
Throw proper error if no dict is passed, use proper string format

### DIFF
--- a/dicthash/dicthash.py
+++ b/dicthash/dicthash.py
@@ -114,7 +114,9 @@ def generate_hash_from_dict(d, blacklist=None, whitelist=None, raw=False):
     '6725c9cd61278978b124dbd61a1cfb6a'
 
     """
-    assert(isinstance(d, dict)), 'Please provide a dictionary.'
+    if not isinstance(d, dict):
+        raise TypeError('Please provide a dictionary.')
+
     if blacklist is not None:
         validate_blackwhitelist(d, blacklist)
     if whitelist is not None:
@@ -131,4 +133,4 @@ def validate_blackwhitelist(d, l):
     dictionary d"""
     for key in l:
         if key not in d.keys():
-            raise KeyError('Key "%s" not found in dictionary. Invalid black/whitelist.' % (key))
+            raise KeyError('Key "{key}" not found in dictionary. Invalid black/whitelist.'.format(key=key))

--- a/dicthash/test/test_dicthash.py
+++ b/dicthash/test/test_dicthash.py
@@ -46,7 +46,7 @@ class DictHashTest(unittest.TestCase):
         self.assertEqual(expected_hash, hash0)
 
     def test_fails_with_non_dict(self):
-        self.assertRaises(AssertionError, dicthash.generate_hash_from_dict, 2)
+        self.assertRaises(TypeError, dicthash.generate_hash_from_dict, 2)
 
     def test_same_value_for_same_dict(self):
         d0 = {


### PR DESCRIPTION
Instead of just raising an `AssertionError` we now throw a `TypeError` if the function is called with anything other than a dictionary.