### PR TITLE
travis ci: install h5py_wrapper from pip 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=$HOME/miniconda2/bin:$PATH
-  - cd ../ && git clone --quiet --depth 5 https://github.com/INM-6/h5py_wrapper.git && cd python-dicthash/
   - conda create --yes -n myenv python=$TRAVIS_PYTHON_VERSION
   - source activate myenv
   - pip install --upgrade pip
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy nose h5py
   - pip install --upgrade quantities future
+  - pip install h5py_wrapper
 script:
   - nosetests


### PR DESCRIPTION
... instead of cloning developer version from github. Fixes #15 .