### PR TITLE
Implement switch to round down floats smaller than the precision to zero

### DIFF
--- a/dicthash/dicthash.py
+++ b/dicthash/dicthash.py
@@ -15,12 +15,18 @@ generate_hash_from_dict - generate an md5 hash from a (nested) dictionary
 
 from future.builtins import str
 import hashlib
+import warnings
 FLOAT_FACTOR = 1e15
+FLOOR_SMALL_FLOATS = False
+
+# user warnings are printed to sys.stdout
+warnings.simplefilter('default', category=UserWarning)
 
 try:
     basestring  # attempt to evaluate basestring
 except NameError:
     basestring = str
+
 
 def _save_convert_float_to_int(x):
     """convert a float x to and int. avoid rounding errors on different
@@ -29,7 +35,12 @@ def _save_convert_float_to_int(x):
 
     """
     if abs(x) > 0. and abs(x) < 1. / FLOAT_FACTOR:
-        raise ValueError('Float too small for safe conversion to integer.')
+        if not FLOOR_SMALL_FLOATS:
+            raise ValueError('Float too small for safe conversion to integer.')
+        else:
+            x = 0.
+            warnings.warn('Float too small for safe conversion to'
+                          'integer. Rounding down to zero.', UserWarning)
     return int(x * FLOAT_FACTOR)
 
 


### PR DESCRIPTION
This PR introduces a way to handle float smaller than the precision. Previously, floats smaller than prevision were silently rounded to zero or raised an error.

The new switch `FLOOR_SMALL_FLOATS` makes this explicit and allows the user to specify the desired behavior. If the switch is set to `false`, a warning is raised.