### PR TITLE
Implement option to specify keys of subdirectories in black/whitelist

### DIFF
--- a/dicthash/test/test_dicthash.py
+++ b/dicthash/test/test_dicthash.py
@@ -299,3 +299,28 @@ def test_store_and_rehash_h5py():
     hash1 = dicthash.generate_hash_from_dict(d1)
 
     assert(hash0 == hash1)
+
+
+def test_subdir_keys_for_whitelist_blacklist():
+    d0 = {'a': {'b': 1,
+                'c': 2},
+          'd': 1}
+    d1 = {'a': {'b': 1,
+                'c': 3},
+          'd': 1}
+
+    label0 = dicthash.generate_hash_from_dict(d0, blacklist=[('a', 'c')])
+    label1 = dicthash.generate_hash_from_dict(d1, blacklist=[('a', 'c')])
+    assert(label0 == label1)
+
+    label0 = dicthash.generate_hash_from_dict(d0, blacklist=[('a', 'b')])
+    label1 = dicthash.generate_hash_from_dict(d1, blacklist=[('a', 'b')])
+    assert(label0 != label1)
+
+    label0 = dicthash.generate_hash_from_dict(d0, whitelist=[('a', 'c')])
+    label1 = dicthash.generate_hash_from_dict(d1, whitelist=[('a', 'c')])
+    assert(label0 != label1)
+
+    label0 = dicthash.generate_hash_from_dict(d0, whitelist=[('a', 'b')])
+    label1 = dicthash.generate_hash_from_dict(d1, whitelist=[('a', 'b')])
+    assert(label0 == label1)


### PR DESCRIPTION
This PR implements the option to specify keys in deeper subdirectories by packaging them into `tuple` objects. To achieve this, the function `validate_blackwhitelist` is now implemented in a recursive manner. Furthermore, `filter_blackwhitelist` filters a given whitelist for the appropriate keys for a given "super"-key.

This addresses #28 .