### PR TITLE
Replace deprecated h5py_wrapper functions

### DIFF
--- a/dicthash/test/test_dicthash.py
+++ b/dicthash/test/test_dicthash.py
@@ -294,8 +294,8 @@ def test_store_and_rehash_h5py():
         'e': True
     }
     hash0 = dicthash.generate_hash_from_dict(d0)
-    h5w.add_to_h5('store_and_rehash_h5py.h5', {'d0': d0}, 'w')
-    d1 = h5w.load_h5('store_and_rehash_h5py.h5', 'd0')
+    h5w.save('store_and_rehash_h5py.h5', {'d0': d0}, 'w')
+    d1 = h5w.load('store_and_rehash_h5py.h5', 'd0')
     hash1 = dicthash.generate_hash_from_dict(d1)
 
     assert(hash0 == hash1)


### PR DESCRIPTION
This PR replaces the deprecated functions of the h5py_wrapper, which will be removed in the upcoming release of the h5py_wrapper.