### PR TITLE
Upgrade Travis and README to Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Conveniently generate portable md5 hashes from (arbitrarily nested) dictionaries
 It exposes just a single function to the user `dicthash.generate_hash_from_dict`.
 
 ![Python2.7](https://img.shields.io/badge/python-2.7-blue.svg)
-![Python3.5](https://img.shields.io/badge/python-3.5-blue.svg)
+![Python3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 Code status
 ===========


### PR DESCRIPTION
Update the travis build to python 3.6 and update information in README file.

Note that the testsuite still fails because of the h5py_wrapper.