### PR TITLE
Fix two bugs with nested blacklists

### DIFF
--- a/dicthash/dicthash.py
+++ b/dicthash/dicthash.py
@@ -122,11 +122,14 @@ def _generate_string_from_dict(d, blacklist, whitelist, prefix=''):
     if blacklist is not None:
         whitelist = set(whitelist).difference(blacklist)
     # Sort whitelist according to the keys converted to str
-    return ''.join(_unpack_value(d[key],
-                                 whitelist=filter_blackwhitelist(whitelist, key),
-                                 blacklist=filter_blackwhitelist(blacklist, key),
-                                 prefix=prefix + str(key)) for
-                   key in sorted(filter_blackwhitelist(whitelist, None), key=str))
+    if len(whitelist) > 0:
+        return ''.join(_unpack_value(d[key],
+                                     whitelist=filter_blackwhitelist(whitelist, key),
+                                     blacklist=filter_blackwhitelist(blacklist, key),
+                                     prefix=prefix + str(key)) for
+                       key in sorted(filter_blackwhitelist(whitelist, None), key=str))
+    else:
+        return ''
 
 
 def generate_hash_from_dict(d, blacklist=None, whitelist=None,
@@ -243,7 +246,10 @@ def filter_blackwhitelist(l, key):
         for k in l:
             if isinstance(k, tuple):
                 if key is not None and k[0] == key:
-                    fl.append(k[1])
+                    if len(k) == 2:
+                        fl.append(k[1])
+                    else:
+                        fl.append(k[1:])
                 elif key is None:
                     fl.append(k[0])
             elif key is None:

--- a/dicthash/test/test_dicthash.py
+++ b/dicthash/test/test_dicthash.py
@@ -224,6 +224,17 @@ def test_blacklist():
     assert(hash0 != hash1)
 
 
+def test_blacklist_all_keys():
+    d0 = {'a': 1,
+          'b': 2}
+    d1 = {}
+
+    hash0 = dicthash.generate_hash_from_dict(d0, blacklist=['a', 'b'])
+    hash1 = dicthash.generate_hash_from_dict(d1)
+    
+    assert(hash0 == hash1)
+
+
 def test_whitelist():
     d0 = {
         'a': [1, 2, 3],

--- a/dicthash/test/test_dicthash.py
+++ b/dicthash/test/test_dicthash.py
@@ -346,6 +346,15 @@ def test_subdir_keys_for_whitelist_blacklist():
     label1 = dicthash.generate_hash_from_dict(d1, whitelist=[('a', 'b')])
     assert(label0 == label1)
 
+    # Test with one more level in the dictionaries
+    d0 = {'e': {'f': {'g': 2,
+                      'h': 4}}}
+    d1 = {'e': {'f': {'g': 3,
+                      'h': 4}}}
+    label0 = dicthash.generate_hash_from_dict(d0, blacklist=[('e', 'f', 'h')])
+    label1 = dicthash.generate_hash_from_dict(d1, blacklist=[('e', 'f', 'h')])
+    assert(label0 != label1)
+
 
 def test_dict_list_lead_to_different_hash():
     d0 = {


### PR DESCRIPTION
This PR fixes two bugs:

- It was not possible to exclude all keys of a dictionary or subdictionary from the label creation
- It was not possible to specifically exclude keys from a subdictionary that is 2 levels or more deep in the dictionary.

