### PR TITLE
Replace conda installation of numpy by pip install to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - source activate myenv
   - pip install --upgrade pip
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy
+  - pip install numpy
   - pip install --upgrade quantities future
   - pip install pytest pytest-cov coveralls
   - pip install h5py_wrapper


### PR DESCRIPTION
For some reason, the conda installation of numpy in the continuous integration was broken. Simply replacing it by a pip installation fixes the problem.