### PR TITLE
Enh/py37 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ branches:
   only:
     - master
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=$HOME/miniconda2/bin:$PATH
+  - export PATH=$HOME/miniconda3/bin:$PATH
   - conda create --yes -n myenv python=$TRAVIS_PYTHON_VERSION
   - source activate myenv
   - pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The user can set two global parameters:
 
 [![Python2.7](https://img.shields.io/badge/python-2.7-blue.svg)](https://www.python.org/downloads/release/python-2714/)
 [![Python3.6](https://img.shields.io/badge/python-3.6-red.svg)](https://www.python.org/downloads/release/python-369/)
+[![Python3.7](https://img.shields.io/badge/python-3.7-red.svg)](https://www.python.org/)
 [![Documentation](https://readthedocs.org/projects/python-dicthash/badge/?version=latest)](https://python-dicthash.readthedocs.io/en/latest/)
 [![PyPI version fury.io](https://d25lcipzij17d.cloudfront.net/badge.svg?id=py&type=6&v=0.0.2&x2=0)](https://pypi.org/project/dicthash/)
 [![GPL license](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)


### PR DESCRIPTION
This PR adds Python 3.7 to the Continuous Integration and documents support for Python 3.7 in the README file.

Relies on #40 .