### PR TITLE
Add test to check that FLOOR_SMALL_FLOATS throws warning when applied

### DIFF
--- a/dicthash/test/test_dicthash_regression.py
+++ b/dicthash/test/test_dicthash_regression.py
@@ -52,6 +52,15 @@ def test_error_for_failing_float_conversion():
     with pytest.raises(ValueError):
         dicthash.generate_hash_from_dict(d3)
 
+def test_floor_small_floats_throws_warning():
+    d = {'a': 1.e-16}
+
+    dicthash.FLOOR_SMALL_FLOATS = True
+    with pytest.warns(UserWarning):
+        dicthash.generate_hash_from_dict(d)
+    # Reset FLOOR_SMALL_FLOATS to default behavior
+    dicthash.FLOOR_SMALL_FLOATS = False
+    
 def test_shuffled_whitelist_leads_to_same_hash():
     d0 = {
         'a': [1, 2, 3],


### PR DESCRIPTION
This PR adds a test to check that when `FLOOR_SMALL_FLOATS=True`, the library throws a warning to the user when this is actually applied.

The setting and resetting of `FLOOR_SMALL_FLOATS` in the test is not very elegant but I don't know if there is a better way to do this.