### PR TITLE
Fix version number in init file

### DIFF
--- a/dicthash/__init__.py
+++ b/dicthash/__init__.py
@@ -17,4 +17,4 @@ It exposes a single function to the user `dicthash.generate_hash_from_dict`.
 
 from .dicthash import generate_hash_from_dict
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'


### PR DESCRIPTION
The version number in the `__init__.py` was still at `0.0.1`. I modified it to `0.0.2_dev`, not sure what is actually the convention?