### PR TITLE
Remove code necessary for Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
+  - "3.8"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The user can set two global parameters:
   throw an error in this case.
   
 
-[![Python2.7](https://img.shields.io/badge/python-2.7-blue.svg)](https://www.python.org/downloads/release/python-2714/)
 [![Python3.6](https://img.shields.io/badge/python-3.6-red.svg)](https://www.python.org/downloads/release/python-369/)
 [![Python3.7](https://img.shields.io/badge/python-3.7-red.svg)](https://www.python.org/)
+[![Python3.8](https://img.shields.io/badge/python-3.8-red.svg)](https://www.python.org/)
 [![Documentation](https://readthedocs.org/projects/python-dicthash/badge/?version=latest)](https://python-dicthash.readthedocs.io/en/latest/)
 [![PyPI version fury.io](https://d25lcipzij17d.cloudfront.net/badge.svg?id=py&type=6&v=0.0.2&x2=0)](https://pypi.org/project/dicthash/)
 [![GPL license](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)

--- a/dicthash/dicthash.py
+++ b/dicthash/dicthash.py
@@ -11,8 +11,6 @@ generate_hash_from_dict - generate an md5 hash from a (nested)
 dictionary
 
 """
-
-from future.builtins import str
 import hashlib
 import warnings
 FLOAT_FACTOR = 1e15
@@ -20,11 +18,6 @@ FLOOR_SMALL_FLOATS = False
 
 # user warnings are printed to sys.stdout
 warnings.simplefilter('default', category=UserWarning)
-
-try:
-    basestring  # attempt to evaluate basestring
-except NameError:
-    basestring = str
 
 
 def _save_convert_float_to_int(x):
@@ -94,7 +87,7 @@ def _generate_string_from_iterable(l, prefix=''):
 
     # we need to handle strings separately to avoid infinite recursion
     # due to their iterable property
-    if isinstance(l, basestring):
+    if isinstance(l, str):
         return ''.join((prefix, str(l)))
     else:
         return ''.join(_unpack_value(value, prefix='') for value in l)


### PR DESCRIPTION
This PR removes the Python 2 support. This enables us to use advances introduced in Python 3 without needing to guarantee backwards-compatibility. Fixes #44 .

Also adds Python 3.8 to CI --> Fixes #46 