### PR TITLE
Add type annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ install:
   - pip install --upgrade quantities future
   - pip install pytest pytest-cov coveralls
   - pip install h5py_wrapper
+  - pip install mypy
 script:
   - pytest --cov=dicthash
+  - mypy dicthash/dicthash.py
 after_success:
   - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
+  - "3.8"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The user can set two global parameters:
   throw an error in this case.
   
 
-[![Python2.7](https://img.shields.io/badge/python-2.7-blue.svg)](https://www.python.org/downloads/release/python-2714/)
 [![Python3.6](https://img.shields.io/badge/python-3.6-red.svg)](https://www.python.org/downloads/release/python-369/)
 [![Python3.7](https://img.shields.io/badge/python-3.7-red.svg)](https://www.python.org/)
+[![Python3.8](https://img.shields.io/badge/python-3.8-red.svg)](https://www.python.org/)
 [![Documentation](https://readthedocs.org/projects/python-dicthash/badge/?version=latest)](https://python-dicthash.readthedocs.io/en/latest/)
 [![PyPI version fury.io](https://d25lcipzij17d.cloudfront.net/badge.svg?id=py&type=6&v=0.0.2&x2=0)](https://pypi.org/project/dicthash/)
 [![GPL license](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)

--- a/dicthash/dicthash.py
+++ b/dicthash/dicthash.py
@@ -118,7 +118,7 @@ def _generate_string_from_dict(d: dict, blacklist: Optional[List[Hashable]] = No
         List of keys to exclude from conversion. Blacklist overrules
         whitelist, i.e., keys appearing in the blacklist will
         definitely not be used.
-    whitelist: list, optional
+    whitelist: List[Hashable], optional
         List of keys to include in conversion.
     """
     if whitelist is None:

--- a/dicthash/dicthash.py
+++ b/dicthash/dicthash.py
@@ -11,8 +11,6 @@ generate_hash_from_dict - generate an md5 hash from a (nested)
 dictionary
 
 """
-
-from future.builtins import str
 import hashlib
 import warnings
 FLOAT_FACTOR = 1e15
@@ -20,11 +18,6 @@ FLOOR_SMALL_FLOATS = False
 
 # user warnings are printed to sys.stdout
 warnings.simplefilter('default', category=UserWarning)
-
-try:
-    basestring  # attempt to evaluate basestring
-except NameError:
-    basestring = str
 
 
 def _save_convert_float_to_int(x):
@@ -94,7 +87,7 @@ def _generate_string_from_iterable(l, prefix=''):
 
     # we need to handle strings separately to avoid infinite recursion
     # due to their iterable property
-    if isinstance(l, basestring):
+    if isinstance(l, str):
         return ''.join((prefix, str(l)))
     else:
         return ''.join(_unpack_value(value, prefix='') for value in l)

--- a/dicthash/dicthash.py
+++ b/dicthash/dicthash.py
@@ -46,8 +46,8 @@ def _save_convert_float_to_int(x: float) -> int:
 
 
 def _unpack_value(value: Union[dict, Iterable, float, int],
-                  prefix: str ='', whitelist: Optional[List[Hashable]] =None,
-                  blacklist: Optional[List[Hashable]]=None) -> str:
+                  prefix: str = '', whitelist: Optional[List[Hashable]] = None,
+                  blacklist: Optional[List[Hashable]] = None) -> str:
     """
     Unpack values from a data structure and convert to string. Call
     the corresponding functions for dict or iterables or use simple
@@ -84,7 +84,7 @@ def _unpack_value(value: Union[dict, Iterable, float, int],
                 return prefix + str(value)
 
 
-def _generate_string_from_iterable(l: Iterable, prefix: str ='') -> str:
+def _generate_string_from_iterable(l: Iterable, prefix: str = '') -> str:
     """
     Convert an iterable to a string, by extracting every value. Takes
     care of proper handling of floats to avoid rounding errors.
@@ -104,7 +104,7 @@ def _generate_string_from_iterable(l: Iterable, prefix: str ='') -> str:
 
 
 def _generate_string_from_dict(d: dict, blacklist: Optional[List[Hashable]] = None,
-                               whitelist: Optional[List[Hashable]] = None, prefix: str ='') ->str:
+                               whitelist: Optional[List[Hashable]] = None, prefix: str = '') ->str:
     """
     Convert a dictionary to a string, by extracting every key value
     pair. Takes care of proper handling of floats, iterables and nested

--- a/dicthash/dicthash.py
+++ b/dicthash/dicthash.py
@@ -126,7 +126,7 @@ def _generate_string_from_dict(d: dict, blacklist: Optional[List[Hashable]] = No
     if blacklist is not None:
         whitelist = list(set(whitelist).difference(blacklist))
     # Sort whitelist according to the keys converted to str
-    if len(whitelist) > 0 and whitelist is not None:
+    if len(whitelist) > 0:
         return ''.join(_unpack_value(d[key],
                                      whitelist=filter_blackwhitelist(whitelist, key),
                                      blacklist=filter_blackwhitelist(blacklist, key),


### PR DESCRIPTION
This PR:
- adds type hints to `dicthash.py` and adapts the code at several places due to errors raised by the static type checker mypy.
One major change was to remove the `try. .. except ...` construction in `_unpack_value`.
- adds static type checking with mypy to the CI suite.

This relies on #47 , because type hints only work with Python 3. That is why the code changes of #47 appear here as well. Thus, #47 should be merged first.

This PR fixes #45 